### PR TITLE
Filter out wordpress tables from doctrine migrations diff

### DIFF
--- a/src/DependencyInjection/SwordExtension.php
+++ b/src/DependencyInjection/SwordExtension.php
@@ -2,6 +2,7 @@
 
 namespace Sword\SwordBundle\DependencyInjection;
 
+use Doctrine\Bundle\DoctrineBundle\Dbal\RegexSchemaAssetFilter;
 use NumberNine\Common\Bundle\MergeConfigurationTrait;
 use Sword\SwordBundle\Service\WordpressService;
 use Symfony\Component\Config\FileLocator;
@@ -80,5 +81,11 @@ final class SwordExtension extends ConfigurableExtension implements PrependExten
             ;
             $loader->registerClasses($definition, $mergedConfig['widgets_namespace'], $mergedConfig['widgets_path']);
         }
+
+        $definition = new Definition(RegexSchemaAssetFilter::class, ['~^(?!(%sword.table_prefix%))~']);
+        $definition->addTag('doctrine.dbal.schema_filter', [
+            'connection' => 'default',
+        ]);
+        $container->setDefinition('doctrine.dbal.default_regex_schema_filter', $definition);
     }
 }


### PR DESCRIPTION
Fixes a bug that caused `bin/console make:migration` to generate code that drops all WordPress tables.

Now all tables starting by `%sword.table_prefix%` (`wp_` by default) will be ignored.