### PR TITLE
Remove internal from nginx config to fix no-permalinks in wordpress

### DIFF
--- a/install/docker/nginx/conf.d/default.conf
+++ b/install/docker/nginx/conf.d/default.conf
@@ -24,7 +24,6 @@ server {
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param HTTPS on;
-        internal;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
Fixes #8 for new installations