### PR TITLE
Remove parentheses from require in wp-config

### DIFF
--- a/install/wp/wp-config.php
+++ b/install/wp/wp-config.php
@@ -146,7 +146,7 @@ if (!defined('ABSPATH')) {
 }
 
 /** Sets up WordPress vars and included files. */
-require_once(ABSPATH . 'wp-settings.php');
+require_once ABSPATH . 'wp-settings.php';
 
 /** Handles additional stuff in global scope. */
-require_once(__DIR__ . '/../vendor/phpsword/sword-bundle/src/Loader/wp-load.php');
+require_once __DIR__ . '/../vendor/phpsword/sword-bundle/src/Loader/wp-load.php';


### PR DESCRIPTION
`require` is a statement