### PR TITLE
Reauthenticate user in Symfony when Wordpress user is still logged in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
                 run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
             -   name: Cache dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
                     key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022, William Arin
+Copyright (c) 2022-2023, William Arin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Controller/ReauthenticateController.php
+++ b/src/Controller/ReauthenticateController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sword\SwordBundle\Controller;
+
+use Sword\SwordBundle\Loader\WordpressLoader;
+use Sword\SwordBundle\Security\UserAuthenticator;
+use Sword\SwordBundle\Security\UserProvider;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+
+#[AsController]
+final class ReauthenticateController extends AbstractController
+{
+    #[Route('/reauthenticate', name: Routes::REAUTHENTICATE, priority: 100)]
+    public function reauthenticate(
+        Request $request,
+        WordpressLoader $wordpressLoader,
+        UserAuthenticator $authenticator,
+        UserCheckerInterface $userChecker,
+        UserProvider $userProvider,
+        #[Autowire(service: 'security.authenticator.managers_locator')]
+        ServiceLocator $managersLocator,
+    ): Response {
+        $response = $request->headers->get('referer') === $request->getRequestUri()
+            ? $this->redirectToRoute(Routes::WORDPRESS)
+            : $this->redirect($request->headers->get('referer'));
+
+        $wordpressLoader->loadWordpress();
+
+        if (!is_user_logged_in()) {
+            return $response;
+        }
+
+        $user = $userProvider->loadUserByIdentifier(wp_get_current_user()->user_login);
+        $userChecker->checkPreAuth($user);
+        $managersLocator->get('main')
+            ->authenticateUser($user, $authenticator, $request);
+
+        return $response;
+    }
+}

--- a/src/Controller/Routes.php
+++ b/src/Controller/Routes.php
@@ -7,4 +7,5 @@ namespace Sword\SwordBundle\Controller;
 final class Routes
 {
     public const WORDPRESS = 'sword_wordpress';
+    public const REAUTHENTICATE = 'sword_reauthenticate';
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,6 +18,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('child_theme_translation_domain')->isRequired()->end()
                 ->scalarNode('child_theme_language_path')->defaultValue('%kernel.project_dir%/translations/%sword.child_theme_translation_domain%')->end()
                 ->scalarNode('table_prefix')->defaultValue('wp_')->end()
+                ->scalarNode('app_namespace')->defaultValue('App\\')->end()
                 ->scalarNode('widgets_namespace')->defaultValue('App\\Widget\\')->end()
                 ->scalarNode('widgets_path')->defaultValue('%kernel.project_dir%/src/Widget/')->end()
                 ->arrayNode('public_services')

--- a/src/DependencyInjection/SwordExtension.php
+++ b/src/DependencyInjection/SwordExtension.php
@@ -73,6 +73,7 @@ final class SwordExtension extends ConfigurableExtension implements PrependExten
         $container->setParameter('sword.table_prefix', $mergedConfig['table_prefix']);
         $container->setParameter('sword.public_services', $mergedConfig['public_services']);
         $container->setParameter('sword.widgets_path', $mergedConfig['widgets_path']);
+        $container->setParameter('sword.app_namespace', $mergedConfig['app_namespace']);
 
         if ($mergedConfig['widgets_path'] && file_exists($mergedConfig['widgets_path'])) {
             $definition = (new Definition())

--- a/src/EventListener/WordpressLoggedInStatusCheckEventSubscriber.php
+++ b/src/EventListener/WordpressLoggedInStatusCheckEventSubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sword\SwordBundle\EventListener;
+
+use Sword\SwordBundle\Controller\Routes;
+use Sword\SwordBundle\Loader\WordpressLoader;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+final class WordpressLoggedInStatusCheckEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly WordpressLoader $wordpressLoader,
+        #[Autowire('%sword.app_namespace%')]
+        private readonly string $appNamespace,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            RequestEvent::class => 'checkWordpressLoggedInStatus',
+        ];
+    }
+
+    public function checkWordpressLoggedInStatus(RequestEvent $event): void
+    {
+        $controller = $event->getRequest()
+            ->attributes->get('_controller');
+
+        if (
+            !(str_starts_with($controller, 'Sword\\SwordBundle\\') || str_starts_with($controller, $this->appNamespace))
+            || $event->getRequest()
+                ->attributes->get('_route') === Routes::REAUTHENTICATE
+            || $this->tokenStorage->getToken()?->getUser()
+        ) {
+            return;
+        }
+
+        $cookieName = 'wordpress_logged_in_' . md5($event->getRequest()->getSchemeAndHttpHost());
+
+        if (\array_key_exists($cookieName, $event->getRequest()->cookies->all())) {
+            $this->wordpressLoader->loadWordpress();
+
+            if (!is_user_logged_in()) {
+                $response = new RedirectResponse($event->getRequest()->getRequestUri());
+                $response->headers->removeCookie($cookieName);
+                $event->setResponse($response);
+
+                return;
+            }
+
+            $event->setResponse(new RedirectResponse($this->urlGenerator->generate(Routes::REAUTHENTICATE)));
+        }
+    }
+}

--- a/src/Loader/WordpressLoader.php
+++ b/src/Loader/WordpressLoader.php
@@ -107,6 +107,23 @@ final class WordpressLoader implements EventSubscriberInterface
         return new Response(ob_get_clean(), is_404() ? 404 : 200);
     }
 
+    public function loadWordpress(): void
+    {
+        $url = '/wp-load.php';
+        $request = $this->requestStack->getCurrentRequest();
+
+        global $wordpressLoader;
+        $wordpressLoader = $this;
+
+        foreach (WordpressGlobals::GLOBALS as $global) {
+            global $$global;
+        }
+
+        $entryPoint = $this->wordpressDirectory . '/wp-load.php';
+
+        require_once $entryPoint;
+    }
+
     private function getAuthResponse(string $username, string $password, bool $rememberMe): RedirectResponse
     {
         $session = $this->requestStack->getSession();


### PR DESCRIPTION
Fixes #5

Also adds `WordpressLoader::loadWordpress()` public method that loads only `wp-load.php`, which is useful to execute Wordpress functions.

New config parameter `sword.app_namespace` which defaults to `App\`, to limit the reauth sync to pages of the app.