### PR TITLE
Fix wp_logged_in cookie not correctly cleared

### DIFF
--- a/src/EventListener/WordpressLoggedInStatusCheckEventSubscriber.php
+++ b/src/EventListener/WordpressLoggedInStatusCheckEventSubscriber.php
@@ -52,7 +52,7 @@ final class WordpressLoggedInStatusCheckEventSubscriber implements EventSubscrib
 
             if (!is_user_logged_in()) {
                 $response = new RedirectResponse($event->getRequest()->getRequestUri());
-                $response->headers->removeCookie($cookieName);
+                $response->headers->clearCookie($cookieName);
                 $event->setResponse($response);
 
                 return;


### PR DESCRIPTION
Fixes a bug which caused an infinite redirect loop when `wp_logged_in` cookie was set but the Wordpress user logged out.