### PR TITLE
Fix reauthenticate redirect that caused an impossibility to change page

### DIFF
--- a/src/Controller/ReauthenticateController.php
+++ b/src/Controller/ReauthenticateController.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Sword\SwordBundle\Controller;
 
 use Sword\SwordBundle\Loader\WordpressLoader;
-use Sword\SwordBundle\Security\UserAuthenticator;
-use Sword\SwordBundle\Security\UserProvider;
+use Sword\SwordBundle\Security\UserReauthenticator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\User\UserCheckerInterface;
 
 #[AsController]
 final class ReauthenticateController extends AbstractController
@@ -23,11 +19,7 @@ final class ReauthenticateController extends AbstractController
     public function reauthenticate(
         Request $request,
         WordpressLoader $wordpressLoader,
-        UserAuthenticator $authenticator,
-        UserCheckerInterface $userChecker,
-        UserProvider $userProvider,
-        #[Autowire(service: 'security.authenticator.managers_locator')]
-        ServiceLocator $managersLocator,
+        UserReauthenticator $userReauthenticator,
     ): Response {
         $response = $request->headers->get('referer') === $request->getRequestUri()
             ? $this->redirectToRoute(Routes::WORDPRESS, [
@@ -38,15 +30,7 @@ final class ReauthenticateController extends AbstractController
             ]));
 
         $wordpressLoader->loadWordpress();
-
-        if (!is_user_logged_in()) {
-            return $response;
-        }
-
-        $user = $userProvider->loadUserByIdentifier(wp_get_current_user()->user_login);
-        $userChecker->checkPreAuth($user);
-        $managersLocator->get('main')
-            ->authenticateUser($user, $authenticator, $request);
+        $userReauthenticator->reauthenticate();
 
         return $response;
     }

--- a/src/EventListener/WordpressLoggedInStatusCheckEventSubscriber.php
+++ b/src/EventListener/WordpressLoggedInStatusCheckEventSubscriber.php
@@ -6,19 +6,19 @@ namespace Sword\SwordBundle\EventListener;
 
 use Sword\SwordBundle\Controller\Routes;
 use Sword\SwordBundle\Loader\WordpressLoader;
+use Sword\SwordBundle\Security\UserReauthenticator;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 final class WordpressLoggedInStatusCheckEventSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly TokenStorageInterface $tokenStorage,
-        private readonly UrlGeneratorInterface $urlGenerator,
         private readonly WordpressLoader $wordpressLoader,
+        private readonly UserReauthenticator $userReauthenticator,
         #[Autowire('%sword.app_namespace%')]
         private readonly string $appNamespace,
     ) {
@@ -58,7 +58,8 @@ final class WordpressLoggedInStatusCheckEventSubscriber implements EventSubscrib
                 return;
             }
 
-            $event->setResponse(new RedirectResponse($this->urlGenerator->generate(Routes::REAUTHENTICATE)));
+            $this->userReauthenticator->reauthenticate();
+            $event->setResponse(new RedirectResponse($event->getRequest()->getRequestUri()));
         }
     }
 }

--- a/src/Security/UserReauthenticator.php
+++ b/src/Security/UserReauthenticator.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sword\SwordBundle\Security;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+
+final class UserReauthenticator
+{
+    public function __construct(
+        private readonly UserAuthenticator $authenticator,
+        private readonly UserCheckerInterface $userChecker,
+        private readonly UserProvider $userProvider,
+        private readonly RequestStack $requestStack,
+        #[Autowire(service: 'security.authenticator.managers_locator')]
+        private readonly ServiceLocator $managersLocator,
+    ) {
+    }
+
+    public function reauthenticate(): bool
+    {
+        if (!is_user_logged_in()) {
+            return false;
+        }
+
+        $user = $this->userProvider->loadUserByIdentifier(wp_get_current_user()->user_login);
+        $this->userChecker->checkPreAuth($user);
+        $this->managersLocator->get('main')
+            ->authenticateUser($user, $this->authenticator, $this->requestStack->getMainRequest());
+
+        return true;
+    }
+}


### PR DESCRIPTION
This bug impacted all WordPress pages when user was logged in WordPress and logged out from Symfony.