### PR TITLE
Trying to find env value on $_SERVER if getenv fails

### DIFF
--- a/install/wp/wp-config.php
+++ b/install/wp/wp-config.php
@@ -33,6 +33,10 @@ if (!function_exists('getenv_docker')) {
             return $val;
         }
 
+        if (isset($_SERVER[$env]) && !empty($_SERVER[$env])) {
+            return $_SERVER[$env];
+        }
+
         return $default;
     }
 }


### PR DESCRIPTION
I reopened the topic as we discussed earlier.

I'm running my project without docker, so I have installed symfony manually and then required phpsword/sword-bundle. My current setup:
- symfony 6.3.3
- php 8.1.16
- apache 2.4.52

All of my environment parameters are in the project's default .env file, but Symfony by default not using "putenv" while loading the .env file, so getenv('WP_ANYTHING') returns false in getenv_docker helper function.

If I add these extra lines to my composer.json, then Symfony loads ,env parameters to environment and the getenv() method works as expected.
` "extra": {
        "runtime": {
            "use_putenv": true
        }.........
`
But this is not recommended according to the Symfony documentation: [https://symfony.com/doc/current/components/runtime.html#using-options](url)