### PR TITLE
Add generics annotations for get_symfony_service

### DIFF
--- a/src/Helper/ContainerHelper.php
+++ b/src/Helper/ContainerHelper.php
@@ -7,6 +7,11 @@ namespace Sword\SwordBundle\Helper;
 use Sword\SwordBundle\Loader\WordpressLoader;
 use Sword\SwordBundle\Service\WordpressService;
 
+/**
+ * @template T
+ * @param class-string<T> $serviceId
+ * @return T
+ */
 function get_symfony_service(string $serviceId): mixed
 {
     /** @var WordpressLoader $wordpressLoader */


### PR DESCRIPTION
Now the returned object type is inferred according to the service FCQN.
```php
// No need to @var this variable anymore
$someRepository = get_symfony_service(SomeRepository::class);
```

If it's not a FCQN then you still need to use `@var`.